### PR TITLE
`Contributing`: Added steps to install `rust` and `cargo`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,27 @@ git remote add upstream https://github.com/scribe-org/Scribe-Desktop.git
   - `origin` (forked repository)
   - `upstream` (Scribe-Desktop repository)
 
-2. (Optional) Install [pre-commit](https://pre-commit.com/) and its hooks to check for and correct common errors in commits:
+2. Install Rust and Cargo:
+
+- For Linux and macOS:
+
+Run the following command in your terminal:
+`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+
+Follow the on-screen instructions to complete the installation. You can find more details in the [official Rust documentation](https://doc.rust-lang.org/book/ch01-01-installation.html).
+
+- For Windows:
+
+Download and run [rustup-init.exe](https://rustup.rs/). Follow the instructions in the installer. For more details, visit the [Rust Windows installation guide](https://www.rust-lang.org/tools/install).
+
+After installation, you may need to restart your terminal for the changes to take effect. Verify the installation by running:
+
+```bash
+rustc --version
+cargo --version
+```
+
+3. (Optional) Install [pre-commit](https://pre-commit.com/) and its hooks to check for and correct common errors in commits:
 
 ```bash
 pip install pre-commit
@@ -85,7 +105,7 @@ pre-commit install
 # pre-commit run --all-files
 ```
 
-3. Run the following to spin up a local copy of the Scribe-Desktop GUI:
+4. Run the following to spin up a local copy of the Scribe-Desktop GUI:
 
 ```bash
 cd scribe
@@ -93,7 +113,7 @@ cargo build
 cargo run --bin scribe
 ```
 
-4. You may need to give your terminal or IDE permission for your keyboard strokes to be read
+5. You may need to give your terminal or IDE permission for your keyboard strokes to be read
    - You may also need to restart the application and then run `cargo run --bin scribe` again
 
 > [!NOTE]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,10 @@ git remote add upstream https://github.com/scribe-org/Scribe-Desktop.git
 - For Linux and macOS:
 
 Run the following command in your terminal:
-`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
 
 Follow the on-screen instructions to complete the installation. You can find more details in the [official Rust documentation](https://doc.rust-lang.org/book/ch01-01-installation.html).
 
@@ -97,7 +100,7 @@ rustc --version
 cargo --version
 ```
 
-3. (Optional) Install [pre-commit](https://pre-commit.com/) and its hooks to check for and correct common errors in commits:
+3. (Suggested) Install [pre-commit](https://pre-commit.com/) and its hooks to check for and correct common errors in commits:
 
 ```bash
 pip install pre-commit


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
Updated the `CONTRIBUTING.md` to help first time contributors correctly download and install `rust` and `cargo` on their machines so they can run the application for testing purposes.

### Related issue
N/A
<!--- Scribe-Desktop prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->


