### PR TITLE
Refactor StyleSheet to use Theme for dark mode instead of AppState

### DIFF
--- a/scribe/src/styles.rs
+++ b/scribe/src/styles.rs
@@ -16,7 +16,7 @@ impl button::StyleSheet for ButtonStyle {
     type Style = iced::Theme;
 
     fn active(&self, style: &Self::Style) -> ButtonAppearance {
-        let is_dark = self.state.is_dark_theme;
+        let is_dark = matches!(style, iced::Theme::Dark);
 
         ButtonAppearance {
             background: Some(Background::Color(if is_dark {
@@ -74,7 +74,7 @@ impl text_input::StyleSheet for CustomTextInput {
 
     fn active(&self, style: &Self::Style) -> TextInputAppearance {
         println!("Now we are in the style.rs");
-        let is_dark = self.state.is_dark_theme;
+        let is_dark = matches!(style, iced::Theme::Dark);
         TextInputAppearance {
             background: Background::Color(if is_dark {
                 Color::from_rgb8(0xFF, 0xFF, 0xFF)


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR improves how theme detection is handled in the `ButtonStyle` and `CustomTextInput` components.

Previously, both relied on `AppState` to check if dark mode was active. But since Iced already provides the `style: &Theme` parameter for this exact purpose, we now use:

```rust
let is_dark = matches!(style, Theme::Dark);
```

### Related issue

Closes #27 