### PR TITLE
fix: Added Period(.) Key

### DIFF
--- a/scribe/src/lib.rs
+++ b/scribe/src/lib.rs
@@ -55,6 +55,7 @@ pub fn allowed_keys(key: &Key) -> Option<char> {
         Key::BackQuote => Some('`'),
         Key::Tab => Some('\t'),
         Key::Quote => Some('"'),
+        Key::Dot => Some('.'),
         _ => None,
     }
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
<img width="522" height="146" alt="image" src="https://github.com/user-attachments/assets/15592e94-26b5-49ec-97ab-36c8451ae696" />


---

### Description

There is a "." key missing in lib.rs. So I thought of adding it as I found it available in rdev


@henrikth93 and @andrewtavis  , Please feel free to review it ! Thank you !!


<!--- Scribe-Desktop prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->


