### PR TITLE
Prohibit writing to the text input if not in command mode

### DIFF
--- a/scribe/src/bin/gui.rs
+++ b/scribe/src/bin/gui.rs
@@ -14,7 +14,6 @@ use std::net::TcpListener;
 #[derive(Debug, Clone)]
 pub enum Message {
     KeyReceived(char),
-    ToggleListening,
     ToggleTooltips,
     Translate,
     Conjugate,
@@ -25,7 +24,7 @@ pub enum Message {
 
 struct Scribe {
     keys: String,
-    is_listening: bool,
+    is_executing_command: bool,
     tool_tips: bool,
     state: AppState,
     theme: Theme,
@@ -39,7 +38,7 @@ impl Default for Scribe {
         println!("Initial system theme detected: {:?}", detected_theme);
         Scribe {
             keys: String::new(),
-            is_listening: true,
+            is_executing_command: false,
             tool_tips: false,
             state: AppState {
                 is_dark_theme: is_dark,
@@ -81,7 +80,7 @@ impl Application for Scribe {
     fn update(&mut self, message: Message) -> Command<Self::Message> {
         match message {
             Message::KeyReceived(char) => {
-                if self.is_listening {
+                if self.is_executing_command {
                     let keys = &mut self.keys;
                     if char == '\x08' {
                         keys.pop();
@@ -90,8 +89,8 @@ impl Application for Scribe {
                     }
                 }
             }
-            Message::ToggleListening => self.is_listening = !self.is_listening,
             Message::ToggleTooltips => {
+                self.is_executing_command = false;
                 self.tool_tips = !self.tool_tips;
                 let height = if self.tool_tips { 92.0 } else { 50.0 };
                 return window::resize(
@@ -102,9 +101,18 @@ impl Application for Scribe {
                     },
                 );
             }
-            Message::Translate => println!("Translate"),
-            Message::Conjugate => println!("Conjugate"),
-            Message::Plural => println!("Plural"),
+            Message::Translate => {
+                self.is_executing_command = true;
+                println!("Translate");
+            }
+            Message::Conjugate => {
+                self.is_executing_command = true;
+                println!("Conjugate");
+            }
+            Message::Plural => {
+                self.is_executing_command = true;
+                println!("Plural");
+            }
             Message::ToggleTheme => {
                 self.manual_override = !self.manual_override;
                 self.state.toggle_theme();


### PR DESCRIPTION
This commit will implement a functionality that prohibits a user from writing to the text input if we are not in command mode.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Desktop prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #34


@priyankaforu My fix did not involve a lot of code, so I thought I did it myself, but I want you to review it and see what you think. Feel free to come with suggestions!
