### PR TITLE
Remove theme button from command view

### DIFF
--- a/scribe/src/bin/gui.rs
+++ b/scribe/src/bin/gui.rs
@@ -8,6 +8,8 @@ use std::io::Read;
 use std::net::TcpListener;
 use std::thread::spawn;
 
+const WINDOW_WIDTH: f32 = 495.0;
+
 #[derive(Debug, Clone)]
 pub enum Message {
     KeyReceived(char),
@@ -79,7 +81,7 @@ impl Scribe {
                 self.is_executing_command = self.show_menu;
                 let new_height = if self.show_menu { 94.0 } else { 52.0 };
                 return window::get_latest()
-                    .and_then(move |id| window::resize(id, Size::new(626.0, new_height)));
+                    .and_then(move |id| window::resize(id, Size::new(WINDOW_WIDTH, new_height)));
             }
             Message::Settings => {
                 // Toggle the settings pane on/off and ensure the menu is visible
@@ -281,30 +283,7 @@ impl Scribe {
                 Message::Conjugate,
                 button_width,
             ))
-            .push(self.create_command_button(plural_icon, "Plural", Message::Plural, button_width))
-            .push(
-                Button::new(Container::new("Theme"))
-                    .on_press(Message::ToggleTheme)
-                    .style(move |_theme: &Theme, _status| {
-                        let background_color = iced::Color::from_rgb8(0x4C, 0xAD, 0xE6);
-
-                        button::Style {
-                            background: Some(iced::Background::Color(background_color)),
-                            text_color: if is_dark {
-                                iced::Color::WHITE
-                            } else {
-                                iced::Color::BLACK
-                            },
-                            border: iced::Border {
-                                color: iced::Color::TRANSPARENT,
-                                width: 0.0,
-                                radius: 4.0.into(),
-                            },
-                            shadow: iced::Shadow::default(),
-                        }
-                    })
-                    .width(button_width),
-            );
+            .push(self.create_command_button(plural_icon, "Plural", Message::Plural, button_width));
 
         // If the settings pane is active, replace command buttons with settings UI
         let settings_row = Row::new()
@@ -480,8 +459,8 @@ fn main() -> iced::Result {
         .subscription(Scribe::subscription)
         .theme(Scribe::theme)
         .window(window::Settings {
-            min_size: Some(Size::new(626.0, 52.0)),
-            size: Size::new(626.0, 52.0),
+            min_size: Some(Size::new(WINDOW_WIDTH, 52.0)),
+            size: Size::new(WINDOW_WIDTH, 52.0),
             position: window::Position::Centered,
             resizable: false,
             decorations: true,


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `just` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Desktop/blob/main/CONTRIBUTING.md#testing)

---

### Description

Removes the old theme selector from the command view shown after pressing the Scribe key. The theme toggle remains available in the settings view.

Also reduces the GUI window width so the command view fits the remaining command buttons only.

### Related issue

<!--- Scribe-Desktop prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #46 
