### PR TITLE
feat: add language selection dropdowns to settings

### DIFF
--- a/scribe/src/bin/gui.rs
+++ b/scribe/src/bin/gui.rs
@@ -1,9 +1,11 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 use iced::futures::SinkExt;
 use iced::stream;
-use iced::widget::{button, image::Handle, text_input, Button, Column, Container, Image, Row};
+use iced::widget::{
+    button, image::Handle, pick_list, text_input, Button, Column, Container, Image, Row,
+};
 use iced::{window, Alignment, Element, Font, Length, Size, Subscription, Task, Theme};
-use scribe::AppState;
+use scribe::{state::Language, AppState};
 use std::io::Read;
 use std::net::TcpListener;
 use std::thread::spawn;
@@ -57,6 +59,8 @@ pub enum Message {
     Plural,
     ExecuteCommand,
     ToggleTheme,
+    FromLanguageSelected(Language),
+    ToLanguageSelected(Language),
     NoOp,
 }
 
@@ -89,6 +93,8 @@ impl Default for Scribe {
             show_settings: false,
             state: AppState {
                 is_dark_theme: is_dark,
+                from_language: Language::default(),
+                to_language: Language::default(),
             },
             theme: detected_theme,
         }
@@ -113,27 +119,25 @@ impl Scribe {
             }
             Message::ToggleMenu => {
                 self.show_menu = !self.show_menu;
-                // closing the menu should also close the settings pane
                 if !self.show_menu {
                     self.show_settings = false;
-                }
-                self.is_executing_command = self.show_menu;
-                if !self.show_menu {
                     self.selected_command = None;
                 }
+                self.is_executing_command = self.show_menu;
                 let new_height = if self.show_menu { 94.0 } else { 52.0 };
                 return window::get_latest()
                     .and_then(move |id| window::resize(id, Size::new(WINDOW_WIDTH, new_height)));
             }
             Message::Settings => {
-                // Toggle the settings pane on/off and ensure the menu is visible
                 self.show_settings = !self.show_settings;
                 if self.show_settings {
                     self.show_menu = true;
                     self.is_executing_command = true;
                     self.selected_command = None;
                 }
-                println!("Settings clicked: show_settings={}", self.show_settings);
+                let new_height = if self.show_settings { 160.0 } else { 94.0 };
+                return window::get_latest()
+                    .and_then(move |id| window::resize(id, Size::new(WINDOW_WIDTH, new_height)));
             }
             Message::Translate => {
                 self.select_command(CommandKind::Translate);
@@ -152,6 +156,12 @@ impl Scribe {
             }
             Message::TextInputChanged(new_text) => {
                 self.keys = new_text;
+            }
+            Message::FromLanguageSelected(lang) => {
+                self.state.from_language = lang;
+            }
+            Message::ToLanguageSelected(lang) => {
+                self.state.to_language = lang;
             }
             Message::ToggleTheme => {
                 self.state.toggle_theme();
@@ -367,7 +377,33 @@ impl Scribe {
             ));
 
         // If the settings pane is active, replace command buttons with settings UI
-        let settings_row = Row::new()
+        let from_row = Row::new()
+            .spacing(10)
+            .align_y(Alignment::Center)
+            .push(Container::new("Translate from:").width(Length::Fill))
+            .push(
+                pick_list(
+                    &Language::ALL[..],
+                    Some(self.state.from_language),
+                    Message::FromLanguageSelected,
+                )
+                .width(settings_button_width),
+            );
+
+        let to_row = Row::new()
+            .spacing(10)
+            .align_y(Alignment::Center)
+            .push(Container::new("Translate to:").width(Length::Fill))
+            .push(
+                pick_list(
+                    &Language::ALL[..],
+                    Some(self.state.to_language),
+                    Message::ToLanguageSelected,
+                )
+                .width(settings_button_width),
+            );
+
+        let theme_row = Row::new()
             .spacing(10)
             .align_y(Alignment::Center)
             .push(
@@ -402,6 +438,12 @@ impl Scribe {
                 .width(settings_button_width),
             );
 
+        let settings_column = Column::new()
+            .spacing(10)
+            .push(from_row)
+            .push(to_row)
+            .push(theme_row);
+
         // Right column with input and buttons.
         let input_row = Row::new()
             .spacing(10)
@@ -420,7 +462,7 @@ impl Scribe {
         // Only show buttons when menu is open.
         if self.show_menu {
             if self.show_settings {
-                right_column = right_column.push(settings_row);
+                right_column = right_column.push(settings_column);
             } else {
                 right_column = right_column.push(button_row);
             }

--- a/scribe/src/bin/gui.rs
+++ b/scribe/src/bin/gui.rs
@@ -135,7 +135,7 @@ impl Scribe {
                     self.is_executing_command = true;
                     self.selected_command = None;
                 }
-                let new_height = if self.show_settings { 160.0 } else { 94.0 };
+                let new_height = if self.show_settings { 170.0 } else { 94.0 };
                 return window::get_latest()
                     .and_then(move |id| window::resize(id, Size::new(WINDOW_WIDTH, new_height)));
             }

--- a/scribe/src/lib.rs
+++ b/scribe/src/lib.rs
@@ -2,3 +2,4 @@
 pub mod state;
 pub mod styles;
 pub use state::AppState;
+pub use state::Language;

--- a/scribe/src/state.rs
+++ b/scribe/src/state.rs
@@ -1,7 +1,52 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Language {
+    #[default]
+    English,
+    French,
+    German,
+    Italian,
+    Portuguese,
+    Russian,
+    Spanish,
+    Swedish,
+}
+
+impl Language {
+    pub const ALL: [Language; 8] = [
+        Language::English,
+        Language::French,
+        Language::German,
+        Language::Italian,
+        Language::Portuguese,
+        Language::Russian,
+        Language::Spanish,
+        Language::Swedish,
+    ];
+}
+
+impl fmt::Display for Language {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Language::English => write!(f, "English"),
+            Language::French => write!(f, "French"),
+            Language::German => write!(f, "German"),
+            Language::Italian => write!(f, "Italian"),
+            Language::Portuguese => write!(f, "Portuguese"),
+            Language::Russian => write!(f, "Russian"),
+            Language::Spanish => write!(f, "Spanish"),
+            Language::Swedish => write!(f, "Swedish"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AppState {
     pub is_dark_theme: bool,
+    pub from_language: Language,
+    pub to_language: Language,
 }
 
 impl AppState {


### PR DESCRIPTION


<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have tested my code with the `just` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Desktop/blob/main/CONTRIBUTING.md#testing)

---

### Description

Adds language selection UI to the settings panel so users can choose which language to translate from and to.
Add Language enum with 8 supported languages (EN, FR, DE, IT, PT, RU, ES, SV). Add from/to language pick_list dropdowns in settings panel above theme toggle. Resize settings panel to accommodate the two additional rows.

**Files changed:**

1. scribe/src/state.rs: Added Language enum with 8 supported languages (English, French, German, Italian, Portuguese, Russian, Spanish, Swedish), with Display impl for dropdown labels. Added from_language and to_language fields to AppState.
2. scribe/src/lib.rs: Re-exported Language from the crate root.
3. scribe/src/bin/gui.rs: Added two pick_list dropdowns ("Translate from:" / "Translate to:") in the settings panel above the existing theme toggle. Settings panel now resizes to 160px height to accommodate the extra rows. Added FromLanguageSelected and ToLanguageSelected message variants.

**Testing:** 
Ran cargo run --bin gui, opened settings panel, verified both dropdowns appear and are selectable.

### Related issue

<!--- Scribe-Desktop prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #20 
