### PR TITLE
Create a clear text input button

### DIFF
--- a/scribe/src/bin/gui.rs
+++ b/scribe/src/bin/gui.rs
@@ -58,6 +58,8 @@ pub enum Message {
     Conjugate,
     Plural,
     ExecuteCommand,
+    
+    ClearInput,
     ToggleTheme,
     FromLanguageSelected(Language),
     ToLanguageSelected(Language),
@@ -153,6 +155,9 @@ impl Scribe {
             }
             Message::ExecuteCommand => {
                 self.execute_selected_command();
+            }
+            Message::ClearInput => {
+                self.keys.clear();
             }
             Message::TextInputChanged(new_text) => {
                 self.keys = new_text;
@@ -449,6 +454,7 @@ impl Scribe {
             .spacing(10)
             .align_y(Alignment::Center)
             .push(text_input)
+            .push_maybe((!self.keys.is_empty()).then(|| self.create_clear_button()))
             .push_maybe(
                 self.selected_command
                     .map(|_| self.create_enter_button(Length::Fixed(70.0))),
@@ -607,6 +613,32 @@ impl Scribe {
             })
             .width(width)
     }
+
+    fn create_clear_button<'a>(&self) -> Button<'a, Message> {
+        let is_dark = self.state.is_dark_theme;
+
+        Button::new(Container::new("X").center_x(Length::Fill))
+            .on_press(Message::ClearInput)
+            .style(move |_theme: &Theme, _status| button::Style {
+                background: Some(iced::Background::Color(if is_dark {
+                    iced::Color::from_rgb8(0x4A, 0x4A, 0x4A)
+                } else {
+                    iced::Color::from_rgb8(0xE2, 0xE6, 0xEC)
+                })),
+                text_color: if is_dark {
+                    iced::Color::WHITE
+                } else {
+                    iced::Color::BLACK
+                },
+                border: iced::Border {
+                    color: iced::Color::TRANSPARENT,
+                    width: 0.0,
+                    radius: 4.0.into(),
+                },
+                shadow: iced::Shadow::default(),
+            })
+            .width(Length::Fixed(36.0))
+    }
 }
 
 fn main() -> iced::Result {
@@ -679,5 +711,17 @@ mod tests {
         assert_eq!(s.selected_command, Some(CommandKind::Plural));
         assert!(s.is_executing_command);
         assert!(!s.show_settings);
+    }
+
+    #[test]
+    fn clear_input_empties_keys() {
+        let mut s = Scribe {
+            keys: "a lot of text".to_string(),
+            ..Scribe::default()
+        };
+
+        let _ = s.update(Message::ClearInput);
+
+        assert_eq!(s.keys, "");
     }
 }

--- a/scribe/src/bin/gui.rs
+++ b/scribe/src/bin/gui.rs
@@ -58,7 +58,7 @@ pub enum Message {
     Conjugate,
     Plural,
     ExecuteCommand,
-    
+
     ClearInput,
     ToggleTheme,
     FromLanguageSelected(Language),


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have tested my code with the `just` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Desktop/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request adds a clear button to the GUI text input so users can quickly remove all entered text without repeatedly pressing backspace.

Changes made:
- Added a new `ClearInput` message in `scribe/src/bin/gui.rs`.
- Added a clear button that appears beside the text input when text is present.
- Updated the app state so clicking the button clears the current input.
- Added a unit test to verify that the clear action empties the input text.

### Related issue

<!--- Scribe-Desktop prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

-  Closes #25 
